### PR TITLE
Enable markup formatting for Slack hook texts

### DIFF
--- a/lib/qiita/team/services/hooks/concerns/slack.rb
+++ b/lib/qiita/team/services/hooks/concerns/slack.rb
@@ -56,6 +56,7 @@ module Qiita::Team::Services
               title: event.item.title,
               title_link: event.item.url,
               text: Slacken.translate(event.item.rendered_body),
+              mrkdwn_in: ["text"],
             ],
           )
         end
@@ -117,6 +118,7 @@ module Qiita::Team::Services
               author_link: event.user.url,
               author_icon: event.user.profile_image_url,
               text: Slacken.translate(event.comment.rendered_body),
+              mrkdwn_in: ["text"],
             ],
           )
         end
@@ -161,6 +163,7 @@ module Qiita::Team::Services
               author_link: event.user.url,
               author_icon: event.user.profile_image_url,
               text: Slacken.translate(event.comment.rendered_body),
+              mrkdwn_in: ["text"],
             ],
           )
         end


### PR DESCRIPTION
Review plz @yuku-t 
マークアップされなかったのは `mrkdwn_in` オプションが設定されていなかったのが原因でした。
(参考: https://api.slack.com/docs/formatting のMessage Formattingセクション)

(スクリーンショット: 上が変更前、下が変更後)
![2015-10-20 18 17 28](https://cloud.githubusercontent.com/assets/1477130/10603232/dd054c8e-7757-11e5-8664-55fe98ffda78.png)