### PR TITLE
gem buildした際のビルドエラーを修正

### DIFF
--- a/qiita_team_services.gemspec
+++ b/qiita_team_services.gemspec
@@ -1,7 +1,7 @@
 lib = File.expand_path("../lib", __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
 
-module Qiita
+module ::Qiita
   module Team
     module Services
     end


### PR DESCRIPTION
Review plz @yuku-t 

### `gem build` 実行時のエラー
`gem build`した際に読まれるgemspec内のコードは`Gem::Specification`モジュール内で実行されているらしく、
「定義された`Qiita`モジュールが内部モジュール扱いになってしまう」→「"qiita/team/services/version"を読んだ際にNameErrorになってしまう」みたいです。

https://github.com/rubygems/rubygems/blob/master/lib/rubygems/specification.rb#L1112-L1130
https://github.com/rubygems/rubygems/blob/master/lib/rubygems/commands/build_command.rb#L45

モジュール宣言をトップレベルに移して失敗しないように修正しました。

### エラーログ
```
$ gem build qiita_team_services.gemspec --debug                                                                                                                                            
NOTE:  Debugging mode prints all exceptions even when rescued
Exception `NameError' at /Users/tomoya/Projects/qiita-team-services/lib/qiita/team/services/version.rb:1 - uninitialized constant Qiita
Exception `NameError' at /Users/tomoya/.anyenv/envs/rbenv/versions/2.2.0/lib/ruby/site_ruby/2.2.0/rubygems/specification.rb:1043 - uninitialized constant Qiita
Invalid gemspec in [qiita_team_services.gemspec]: uninitialized constant Qiita
ERROR:  Error loading gemspec. Aborting.
```

