### PR TITLE
Slackへ送信したメッセージの表示の不自然な空白が出てこないようにする

### DIFF
--- a/lib/qiita/team/services/hooks/concerns/slack.rb
+++ b/lib/qiita/team/services/hooks/concerns/slack.rb
@@ -35,8 +35,7 @@ module Qiita::Team::Services
 
         # @return [void]
         def ping
-          fallback = "Test message sent from Qiita:Team"
-          send_message(attachments: [fallback: fallback, pretext: fallback])
+          send_message(text: "Test message sent from Qiita:Team")
         rescue DeliveryError
           nil
         end
@@ -65,12 +64,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def item_updated(event)
-          fallback = "#{user_link(event.user)} updated #{item_link(event.item)}"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} updated #{item_link(event.item)}",
           )
         end
 
@@ -78,12 +73,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def item_became_coediting(event)
-          fallback = "#{user_link(event.user)} changed #{item_link(event.item)} to coedit mode"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} changed #{item_link(event.item)} to coedit mode",
           )
         end
 
@@ -91,12 +82,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def item_destroyed(event)
-          fallback = "#{user_link(event.user)} deleted #{event.item.title}"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} deleted #{event.item.title}",
           )
         end
 
@@ -127,26 +114,17 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def item_comment_updated(event)
-          fallback = "#{user_link(event.user)} updated a #{comment_link(event.comment)}"
-          fallback << " on #{item_link(event.item)}"
-          send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
-          )
+          text = "#{user_link(event.user)} updated a #{comment_link(event.comment)}"
+          text << " on #{item_link(event.item)}"
+          send_message(text: text)
         end
 
         # @param event [Qiita::Team::Services::Events::ItemCommentDestroyed]
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def item_comment_destroyed(event)
-          fallback = "#{user_link(event.user)} deleted a comemnt on #{item_link(event.item)}"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} deleted a comemnt on #{item_link(event.item)}",
           )
         end
 
@@ -172,26 +150,17 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_comment_updated(event)
-          fallback = "#{user_link(event.user)} updated a #{comment_link(event.comment)}"
-          fallback << " on #{project_link(event.project)}"
-          send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
-          )
+          text = "#{user_link(event.user)} updated a #{comment_link(event.comment)}"
+          text << " on #{project_link(event.project)}"
+          send_message(text: text)
         end
 
         # @param event [Qiita::Team::Services::Events::ProjectCommentDestroyed]
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_comment_destroyed(event)
-          fallback = "#{user_link(event.user)} deleted a comemnt on #{project_link(event.project)}"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} deleted a comemnt on #{project_link(event.project)}",
           )
         end
 
@@ -199,12 +168,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def team_member_added(event)
-          fallback = "#{user_link(event.member)} was added to the #{team_link(event.team)} team"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.member)} was added to the #{team_link(event.team)} team",
           )
         end
 
@@ -212,12 +177,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def team_member_removed(event)
-          fallback = "#{event.member.name} was removed from the #{team_link(event.team)} team"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{event.member.name} was removed from the #{team_link(event.team)} team",
           )
         end
 
@@ -225,12 +186,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_created(event)
-          fallback = "#{user_link(event.user)} created #{project_link(event.project)} project"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} created #{project_link(event.project)} project",
           )
         end
 
@@ -238,12 +195,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_updated(event)
-          fallback = "#{user_link(event.user)} updated #{project_link(event.project)} project"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} updated #{project_link(event.project)} project",
           )
         end
 
@@ -251,12 +204,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_destroyed(event)
-          fallback = "#{user_link(event.user)} deleted #{project_link(event.project)} project"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} deleted #{project_link(event.project)} project",
           )
         end
 
@@ -264,12 +213,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_archived(event)
-          fallback = "#{user_link(event.user)} archived #{project_link(event.project)} project"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} archived #{project_link(event.project)} project",
           )
         end
 
@@ -277,12 +222,8 @@ module Qiita::Team::Services
         # @return [void]
         # @raise [Qiita::Team::Services::DeliveryError]
         def project_activated(event)
-          fallback = "#{user_link(event.user)} activated #{project_link(event.project)} project"
           send_message(
-            attachments: [
-              fallback: fallback,
-              pretext: fallback,
-            ],
+            text: "#{user_link(event.user)} activated #{project_link(event.project)} project",
           )
         end
 

--- a/lib/qiita/team/services/hooks/webhook.rb
+++ b/lib/qiita/team/services/hooks/webhook.rb
@@ -13,7 +13,7 @@ module Qiita::Team::Services
 
       validates :token, format: %r{\A[A-Za-z0-9+/=]{20,40}\z}
       validates :url, presence: true,
-                      url: { scheme: ['http', 'https'],
+                      url: { scheme: %w(http https),
                              message: :invalid_scheme,
                              allow_blank: true }
 

--- a/spec/support/matchers/match_slack_text_request.rb
+++ b/spec/support/matchers/match_slack_text_request.rb
@@ -1,0 +1,8 @@
+RSpec::Matchers.define :match_slack_text_request do
+  match do |request_body|
+    request_body.is_a?(Hash) && \
+      request_body.key?(:text) && \
+      !request_body.key?(:attachments) && \
+      request_body[:text].is_a?(String)
+  end
+end


### PR DESCRIPTION
Slackへメッセージ送信する際にpretext, fallbackのみのattachmentsを含めた際に、表示に不自然な空白が入ってしまうようです。
Slack側としてはメッセージをリッチな感じにしたいときだけにattachmentsを使って、それ以外は普通にtextを渡すという想定のようなので、(https://api.slack.com/docs/attachments) pretext, fallbackのみのattachmentsの代わりにtextを含めて送信するようにしました。
