### PR TITLE
Escape special characters for slack markup

### DIFF
--- a/lib/qiita/team/services/hooks/concerns/slack.rb
+++ b/lib/qiita/team/services/hooks/concerns/slack.rb
@@ -247,13 +247,13 @@ module Qiita::Team::Services
         # @param user [Qiita::Team::Services::Resources::User]
         # @return [String]
         def user_link(user)
-          "<#{user.url}|#{user.name}>"
+          "<#{user.url}|#{markup_escape(user.name)}>"
         end
 
         # @param item [Qiita::Team::Services::Resources::Item]
         # @return [String]
         def item_link(item)
-          "<#{item.url}|#{item.title}>"
+          "<#{item.url}|#{markup_escape(item.title)}>"
         end
 
         # @param comment [Qiita::Team::Services::Resources::Comment]
@@ -265,13 +265,27 @@ module Qiita::Team::Services
         # @param project [Qiita::Team::Services::Resources::Project]
         # @return [String]
         def project_link(project)
-          "<#{project.url}|#{project.name}>"
+          "<#{project.url}|#{markup_escape(project.name)}>"
         end
 
         # @param team [Qiita::Team::Services::Resources::Team]
         # @return [String]
         def team_link(team)
-          "<#{team.url}|#{team.name}>"
+          "<#{team.url}|#{markup_escape(team.name)}>"
+        end
+
+        # Escape special characters for Slack markup.
+        #
+        # @see https://api.slack.com/docs/formatting
+        # @param text [String]
+        # @return [String]
+        def markup_escape(text)
+          table_for_escape = {
+            "&" => "&amp;",
+            "<" => "&lt;",
+            ">" => "&gt;",
+          }
+          text.gsub(/[&<>]/, table_for_escape)
         end
       end
     end

--- a/spec/support/factories/users.rb
+++ b/spec/support/factories/users.rb
@@ -5,7 +5,7 @@ FactoryGirl.define do
     id { generate(:id) }
     url_name { "url_name#{id}" }
     name { "name#{id}" }
-    url { "#{build(:team).url}/#{name}" }
+    url { "#{build(:team).url}/#{url_name}" }
     profile_image_url "http://example.com"
   end
 end

--- a/spec/support/matchers/match_slack_text_request.rb
+++ b/spec/support/matchers/match_slack_text_request.rb
@@ -3,6 +3,11 @@ RSpec::Matchers.define :match_slack_text_request do
     request_body.is_a?(Hash) && \
       request_body.key?(:text) && \
       !request_body.key?(:attachments) && \
-      request_body[:text].is_a?(String)
+      request_body[:text].is_a?(String) && \
+      !illegal_slack_link_format?(request_body[:text])
+  end
+
+  def illegal_slack_link_format?(text)
+    text.match(/<[^>]+</)
   end
 end


### PR DESCRIPTION
Slack markupでの特殊文字 (https://api.slack.com/docs/formatting) をエスケープしてリンク記法などが壊れないようにしました。

# Screenshot
![2015-12-03 15 45 40](https://cloud.githubusercontent.com/assets/1477130/11553734/f4c9c04e-99d4-11e5-92ae-87a26dfc1fa0.png)
