### PR TITLE
Update outdated rubocop config

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,5 +23,8 @@ Metrics/MethodLength:
 Metrics/AbcSize:
   Max: 30
 
-Style/TrailingComma:
+Style/TrailingCommaInArguments:
+  EnforcedStyleForMultiline: comma
+
+Style/TrailingCommaInLiteral:
   EnforcedStyleForMultiline: comma

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,9 @@
+AllCops:
+  TargetRubyVersion: 2.1
+
+Style/Alias:
+  EnforcedStyle: prefer_alias_method
+
 Style/StringLiterals:
   EnforcedStyle: double_quotes
 

--- a/Rakefile
+++ b/Rakefile
@@ -3,7 +3,7 @@ require "rspec/core/rake_task"
 require "rubocop/rake_task"
 require "yard"
 
-YARD_DIR = ".publish"
+YARD_DIR = ".publish".freeze
 
 RuboCop::RakeTask.new
 RSpec::Core::RakeTask.new

--- a/lib/qiita/team/services/hooks/concerns/http_client.rb
+++ b/lib/qiita/team/services/hooks/concerns/http_client.rb
@@ -9,7 +9,7 @@ module Qiita::Team::Services
         DEFAULT_HEADERS = {
           "Content-Type" => "application/json",
           "User-Agent" => "Qiita:Team",
-        }
+        }.freeze
         TIMEOUT = 5
 
         private
@@ -48,11 +48,8 @@ module Qiita::Team::Services
               req.headers[key] = value
             end
           end
-          if resp.success?
-            resp
-          else
-            fail DeliveryError
-          end
+          fail DeliveryError unless resp.success?
+          resp
         end
 
         # @return [Symbol] the request format type, `:json` or `:url_encoded`

--- a/lib/qiita/team/services/hooks/slack_v2.rb
+++ b/lib/qiita/team/services/hooks/slack_v2.rb
@@ -13,8 +13,6 @@ module Qiita::Team::Services
                                         message: :not_slack_url,
                                         allow_blank: true }
 
-      private
-
       # @note Implement Concerns::HttpClient#url.
       alias_method :url, :webhook_url
     end

--- a/lib/qiita/team/services/version.rb
+++ b/lib/qiita/team/services/version.rb
@@ -1,3 +1,3 @@
 module Qiita::Team::Services
-  VERSION = "0.3.6"
+  VERSION = "0.3.6".freeze
 end

--- a/qiita_team_services.gemspec
+++ b/qiita_team_services.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "pry"
   spec.add_development_dependency "rake", "~> 10.4"
   spec.add_development_dependency "rspec", "~> 3.3"
-  spec.add_development_dependency "rubocop", "~> 0.33"
+  spec.add_development_dependency "rubocop", "~> 0.36.0"
   spec.add_development_dependency "webmock", "~> 1.21"
   spec.add_development_dependency "yard", "~> 0.8.7"
 end

--- a/spec/hooks/chatwork_v1_spec.rb
+++ b/spec/hooks/chatwork_v1_spec.rb
@@ -14,7 +14,7 @@ describe Qiita::Team::Services::Hooks::ChatworkV1 do
     :project_created,
     :project_updated,
     :team_member_added,
-  ]
+  ].freeze
 
   shared_context "Delivery success" do
     before do

--- a/spec/hooks/hipchat_v1_spec.rb
+++ b/spec/hooks/hipchat_v1_spec.rb
@@ -13,7 +13,7 @@ describe Qiita::Team::Services::Hooks::HipchatV1 do
     :project_created,
     :project_updated,
     :team_member_added,
-  ]
+  ].freeze
 
   shared_context "Delivery success" do
     before do

--- a/spec/support/factory_girl.rb
+++ b/spec/support/factory_girl.rb
@@ -1,8 +1,8 @@
 require "factory_girl"
 
 Dir.glob("spec/support/factories/*.rb")
-  .map { |filepath| filepath.split("/").last.split(".").first }
-  .each { |name| require "support/factories/#{name}" }
+   .map { |filepath| filepath.split("/").last.split(".").first }
+   .each { |name| require "support/factories/#{name}" }
 
 RSpec.configure do |config|
   config.include FactoryGirl::Syntax::Methods


### PR DESCRIPTION
RubocopがStyle/TrailingCommaを分割した(https://github.com/bbatsov/rubocop/commit/a0719f96bc0221cdb99413e033b27c7378520db2 )のに伴い、CIに通らなくなってしまったので設定を新しくしました

(追加された(？)Lintに引っかかっているようなので、そこも直しました)
https://travis-ci.org/increments/qiita-team-services/builds/104853527 )