### PR TITLE
Truncate Slack message text to 7500 bytes

### DIFF
--- a/spec/support/helpers/slack_hook_helper.rb
+++ b/spec/support/helpers/slack_hook_helper.rb
@@ -124,6 +124,12 @@ module Qiita::Team::Services
                 let(:user) { build(:user, name: "<Qiitan>") }
                 it_behaves_like "attachments request hook method"
               end
+
+              context "when the item's body has larger bytesize than the limit" do
+                let(:text_length) { Hooks::Concerns::Slack::TEXT_BYTESIZE_MAX / "あ".bytesize + 1 }
+                let(:resource) { build(:item, rendered_body: "あ" * text_length) }
+                it_behaves_like "attachments request hook method"
+              end
             end
 
             %w(became_coediting destroyed updated).each do |action_name|
@@ -158,6 +164,12 @@ module Qiita::Team::Services
 
               context "when the user's name has angle bracket characters" do
                 let(:user) { build(:user, name: "<Qiitan>") }
+                it_behaves_like "attachments request hook method"
+              end
+
+              context "when the comment's body has larger bytesize than the limit" do
+                let(:text_length) { Hooks::Concerns::Slack::TEXT_BYTESIZE_MAX / "あ".bytesize + 1 }
+                let(:resource) { build(:comment, rendered_body: "あ" * text_length) }
                 it_behaves_like "attachments request hook method"
               end
             end
@@ -215,6 +227,12 @@ module Qiita::Team::Services
 
               context "when the user's name has angle bracket characters" do
                 let(:user) { build(:user, name: "<Qiitan>") }
+                it_behaves_like "attachments request hook method"
+              end
+
+              context "when the comment's body has larger bytesize than the limit" do
+                let(:text_length) { Hooks::Concerns::Slack::TEXT_BYTESIZE_MAX / "あ".bytesize + 1 }
+                let(:resource) { build(:project_comment, rendered_body: "あ" * text_length) }
                 it_behaves_like "attachments request hook method"
               end
             end

--- a/spec/support/matchers/match_slack_attachments_request.rb
+++ b/spec/support/matchers/match_slack_attachments_request.rb
@@ -2,6 +2,12 @@ RSpec::Matchers.define :match_slack_attachments_request do
   match do |request_body|
     request_body.is_a?(Hash) && \
       request_body.key?(:attachments) && \
-      request_body[:attachments].is_a?(Array)
+      request_body[:attachments].is_a?(Array) && \
+      request_body[:attachments].all?(&method(:text_valid_length?))
+  end
+
+  def text_valid_length?(attachment)
+    attachment[:text].nil? || \
+      attachment[:text].bytesize <= Qiita::Team::Services::Hooks::Concerns::Slack::TEXT_BYTESIZE_MAX
   end
 end


### PR DESCRIPTION
Slackが現在8000バイト以上のtextを含む投稿に失敗するので、
(余裕を持って)7500バイト以上の場合切り詰めるするようにしました。

切り詰めた時の末尾が`...`だと分かりにくいかなと思ったので `...(See more...)` にして、投稿やコメントのページへのリンクにしました。

![2016-02-02 17 07 15](https://cloud.githubusercontent.com/assets/1477130/12743231/f64e4644-c9cf-11e5-9507-f4c49f56973f.png)
↑ 動作例
