### PR TITLE
Update URL for Slack incoming webhooks

### DIFF
--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -9,7 +9,7 @@ en:
               Qiita:Team icon is used by default.
             webhook_url_help_block_html:
               You can add incoming webhooks integration to your slack channels at
-              <a href="https://slack.com/integrations" target="_blank">https://slack.com/integrations</a>.
+              <a href="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" target="_blank">https://slack.com/apps/A0F7XDUAZ-incoming-webhooks</a>.
         hooks:
           chatwork_v1:
             room_id: Room ID

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,7 +9,7 @@ ja:
               省略した場合、Qiita:Teamのアイコンが使われます。
             webhook_url_help_block_html: |-
               SlackチャンネルへのIncoming webhooks連携は
-              <a href="https://slack.com/integrations" target="_blank">https://slack.com/integrations</a>
+              <a href="https://slack.com/apps/A0F7XDUAZ-incoming-webhooks" target="_blank">https://slack.com/apps/A0F7XDUAZ-incoming-webhooks</a>
               で追加することができます。
         hooks:
           chatwork_v1:


### PR DESCRIPTION
@yuku-t https://slack.com/integrations は古いURLで現在は https://slack.com/apps が利用されているようです (リダイレクトされるみたいです)。https://slack.com/apps/A0F7XDUAZ-incoming-webhooks がIncoming Webhooks用のURLとして丁度良さそうなので、これに置き換えてみました。
